### PR TITLE
fix(cors): allow all origins

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,8 +16,7 @@ app = FastAPI(title="Vambe Analytics API", version="1.0.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[settings.frontend_url, "http://localhost:5173", "http://localhost:4173"],
-    allow_credentials=True,
+    allow_origins=["*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
Closes #33

Removes origin whitelist — allow_origins=["*"]. The FRONTEND_URL env var approach was fragile for deploy; wildcard is appropriate for a hiring challenge demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)