### PR TITLE
feat(mobile): Header — filter drawer para móvil

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Menu, SlidersHorizontal, X } from "lucide-react"
 import { useQuery } from "@tanstack/react-query"
 import { getFilterOptions } from "@/lib/api"
@@ -21,6 +21,11 @@ export default function Header({ onMenuClick }: HeaderProps) {
   const vendedores: string[] = filterOptions?.vendedor ?? []
 
   const activeCount = [filters.vendedor, filters.dateFrom, filters.dateTo].filter(Boolean).length
+
+  useEffect(() => {
+    document.body.style.overflow = drawerOpen ? "hidden" : ""
+    return () => { document.body.style.overflow = "" }
+  }, [drawerOpen])
 
   const inputClass =
     "h-9 w-full rounded-md border border-input bg-transparent px-2.5 text-sm text-foreground outline-none focus:border-ring focus:ring-2 focus:ring-ring/30"
@@ -158,7 +163,7 @@ export default function Header({ onMenuClick }: HeaderProps) {
             onClick={() => setDrawerOpen(false)}
           />
           {/* Bottom sheet */}
-          <div className="fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-background p-6 shadow-xl lg:hidden">
+          <div className="fixed bottom-0 left-0 right-0 z-50 max-h-[80vh] overflow-y-auto rounded-t-2xl bg-background p-6 shadow-xl lg:hidden">
             <div className="mb-4 flex items-center justify-between">
               <span className="text-base font-semibold">Filtros</span>
               <button


### PR DESCRIPTION
## Summary
- Mobile header fijo en `h-14`: hamburger + título "Vambe Challenge" + botón "Filtros"
- Badge numérico sobre el botón indica cuántos filtros están activos
- Bottom sheet con backdrop semitransparente: date range, vendedor y limpiar apilados verticalmente
- Se cierra con botón X o tocando fuera del drawer
- ExportButton incluido en el drawer en mobile
- Desktop: layout inline sin cambios (wrapped en `hidden lg:flex`)

## Test plan
- [ ] Header en mobile tiene altura fija `h-14` sin desborde
- [ ] Botón "Filtros" muestra badge con el número de filtros activos
- [ ] Bottom sheet se abre/cierra correctamente
- [ ] Tocar fuera del drawer lo cierra
- [ ] Limpiar desde el drawer resetea filtros y cierra el drawer
- [ ] Desktop no tiene cambios visuales

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)