### PR TITLE
fix(config): store allowed_origins as str to avoid pydantic-settings JSON parsing

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,4 @@
-import json
-from typing import Any, Optional
-from pydantic import field_validator
+from typing import Optional
 from pydantic_settings import BaseSettings
 
 
@@ -9,18 +7,14 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/vambe"
     frontend_url: str = "http://localhost:5173"
     csv_path: str = "vambe_clients.csv"
-    allowed_origins: list[str] = ["http://localhost:5173"]
+    # Comma-separated string avoids pydantic-settings trying to JSON-parse a list field.
+    # Use settings.origins property wherever a list is needed.
+    allowed_origins: str = "http://localhost:5173"
     process_api_key: Optional[str] = None
 
-    @field_validator("allowed_origins", mode="before")
-    @classmethod
-    def parse_origins(cls, v: Any) -> Any:
-        if isinstance(v, str):
-            try:
-                return json.loads(v)
-            except json.JSONDecodeError:
-                return [o.strip() for o in v.split(",") if o.strip()]
-        return v
+    @property
+    def origins(self) -> list[str]:
+        return [o.strip() for o in self.allowed_origins.split(",") if o.strip()]
 
     class Config:
         env_file = ".env"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,7 +24,7 @@ app = FastAPI(title="Vambe Analytics API", version="1.0.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.allowed_origins,
+    allow_origins=settings.origins,
     allow_methods=["GET", "POST"],
     allow_headers=["Content-Type", "Authorization", "x-api-key"],
 )


### PR DESCRIPTION
## Summary
- `list[str]` fields in pydantic-settings are JSON-parsed before validators run — a plain URL like `https://foo.vercel.app` causes a `JSONDecodeError` crash on startup
- Changed `allowed_origins` to `str` with a `.origins` property that splits by comma
- Updated `main.py` to use `settings.origins`

## ALLOWED_ORIGINS format in Railway
- Single: `https://vambe-challenge.vercel.app`
- Multiple: `https://foo.vercel.app,https://bar.vercel.app`

## Local
No change needed — default is `http://localhost:5173` when env var is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)