### PR TITLE
feat(explorador): soporte para análisis cruzado — stacked bar y matriz

### DIFF
--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -428,6 +428,49 @@ async def companysize_by_channel(
     ]
 
 
+VALID_DIMENSIONS = {
+    "sector", "vendedor", "discovery_channel", "primary_use_case",
+    "main_pain_point", "client_sentiment", "urgency", "company_size",
+    "interaction_volume_tier", "meeting_depth", "client_engagement",
+}
+
+
+@router.get("/cross")
+async def cross_analysis(
+    dim1: str = Query(...),
+    dim2: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+    gf: dict = Depends(global_filters),
+):
+    from fastapi import HTTPException
+    if dim1 not in VALID_DIMENSIONS or dim2 not in VALID_DIMENSIONS:
+        raise HTTPException(status_code=400, detail=f"Invalid dimension. Valid: {sorted(VALID_DIMENSIONS)}")
+    col1 = getattr(Client, dim1)
+    col2 = getattr(Client, dim2)
+    q = apply_filters(
+        select(
+            col1.label("dim1_value"),
+            col2.label("dim2_value"),
+            func.count(Client.id).label("total"),
+            func.sum(case((Client.closed == True, 1), else_=0)).label("closed"),
+        )
+        .where(col1.isnot(None), col2.isnot(None))
+        .group_by(col1, col2),
+        gf,
+    )
+    result = await db.execute(q)
+    return [
+        {
+            "dim1_value": r.dim1_value,
+            "dim2_value": r.dim2_value,
+            "total": r.total,
+            "closed": int(r.closed or 0),
+            "close_rate": close_rate(int(r.closed or 0), r.total),
+        }
+        for r in result.all()
+    ]
+
+
 @router.post("/insights", response_model=InsightResponse)
 async def get_insights(request: InsightRequest):
     result = await generate_insights(request.metrics)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,6 +69,10 @@ export const getUsecaseByCompanySize = (params?: Record<string, string>) =>
 export const getCompanySizeByChannel = (params?: Record<string, string>) =>
   api.get("/api/analytics/companysize-by-channel", { params }).then((r) => r.data)
 
+// Cross-analysis
+export const getCross = (dim1: string, dim2: string, params?: Record<string, string>) =>
+  api.get("/api/analytics/cross", { params: { dim1, dim2, ...params } }).then((r) => r.data)
+
 // Insights
 export const generateInsights = (metrics: Record<string, unknown>) =>
   api.post("/api/analytics/insights", { metrics }).then((r) => r.data)

--- a/frontend/src/pages/ExplorerPage.tsx
+++ b/frontend/src/pages/ExplorerPage.tsx
@@ -2,11 +2,11 @@ import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
-  LineChart, Line, ScatterChart, Scatter, ZAxis, Legend,
+  LineChart, Line, ScatterChart, Scatter, ZAxis, Legend, Cell,
 } from "recharts"
 import { Loader2, Settings2 } from "lucide-react"
 import { useFilters } from "@/contexts/FiltersContext"
-import { getAllClients } from "@/lib/api"
+import { getAllClients, getCross } from "@/lib/api"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -30,7 +30,7 @@ interface Client {
   client_engagement: string | null
 }
 
-type ChartType = "bar" | "hbar" | "line" | "scatter"
+type ChartType = "bar" | "hbar" | "line" | "scatter" | "matrix"
 
 const DIMENSIONS = [
   { value: "sector", label: "Sector" },
@@ -93,6 +93,19 @@ function groupClients(clients: Client[], dimension: string): { name: string; cli
     .sort((a, b) => b.clients.length - a.clients.length)
 }
 
+function matrixColor(value: number, metric: string, maxCount: number): string {
+  if (metric === "close_rate") {
+    if (value >= 50) return "bg-emerald-100 text-emerald-800"
+    if (value >= 30) return "bg-amber-100 text-amber-800"
+    return "bg-rose-100 text-rose-800"
+  }
+  // count: shade by relative value
+  const pct = maxCount > 0 ? value / maxCount : 0
+  if (pct >= 0.6) return "bg-indigo-100 text-indigo-800"
+  if (pct >= 0.3) return "bg-indigo-50 text-indigo-700"
+  return "bg-muted text-muted-foreground"
+}
+
 // ── Component ──────────────────────────────────────────────────────────────
 export default function ExplorerPage() {
   const { apiParams } = useFilters()
@@ -103,11 +116,19 @@ export default function ExplorerPage() {
   const [scatterY, setScatterY] = useState("close_rate")
   const [colorBy, setColorBy] = useState("")
   const [splitBy, setSplitBy] = useState("")
+  const [stackBy, setStackBy] = useState("")
   const [controlsOpen, setControlsOpen] = useState(false)
 
   const { data: clients, isLoading } = useQuery({
     queryKey: ["all-clients", apiParams],
     queryFn: () => getAllClients(apiParams),
+  })
+
+  // Cross endpoint — only used for matrix chart type
+  const { data: crossData, isLoading: loadingCross } = useQuery({
+    queryKey: ["cross", dimension, stackBy, apiParams],
+    queryFn: () => getCross(dimension, stackBy, apiParams),
+    enabled: chartType === "matrix" && !!stackBy && stackBy !== dimension,
   })
 
   const allClients: Client[] = clients ?? []
@@ -116,7 +137,7 @@ export default function ExplorerPage() {
   const scatterXUnit = METRICS.find((m) => m.value === scatterX)?.unit ?? ""
   const scatterYUnit = METRICS.find((m) => m.value === scatterY)?.unit ?? ""
 
-  // Bar / HBar data
+  // Bar / HBar data (simple)
   const barData = useMemo(() => {
     return groupClients(allClients, dimension).map(({ name, clients }) => ({
       name,
@@ -124,13 +145,30 @@ export default function ExplorerPage() {
     }))
   }, [allClients, dimension, metric])
 
-  // Unique values for the split-by dimension — used by both lineData pivot and Line renders
+  // Stacked bar — unique values of stackBy dimension
+  const stackByValues = useMemo(() => {
+    if (!stackBy) return []
+    return [...new Set(allClients.map((c) => getDimValue(c, stackBy)))].sort()
+  }, [allClients, stackBy])
+
+  // Stacked bar data: rows = dimension values, cols = stackBy values
+  const stackedData = useMemo(() => {
+    if (!stackBy) return []
+    return groupClients(allClients, dimension).map(({ name, clients }) => {
+      const row: Record<string, unknown> = { name }
+      for (const sv of stackByValues) {
+        row[sv] = computeMetric(clients.filter((c) => getDimValue(c, stackBy) === sv), metric)
+      }
+      return row
+    })
+  }, [allClients, dimension, stackBy, stackByValues, metric])
+
+  // Line data: group by month, optionally split by dimension
   const splitByValues = useMemo(() => {
     if (!splitBy) return []
     return [...new Set(allClients.map((c) => getDimValue(c, splitBy)))]
   }, [allClients, splitBy])
 
-  // Line data: group by month, optionally split by dimension
   const lineData = useMemo(() => {
     const monthMap = new Map<string, Client[]>()
     for (const c of allClients) {
@@ -148,7 +186,6 @@ export default function ExplorerPage() {
       }))
     }
 
-    // Pivot: one column per split-by value (reuse splitByValues)
     return months.map((month) => {
       const row: Record<string, unknown> = { month }
       const monthClients = monthMap.get(month)!
@@ -160,11 +197,33 @@ export default function ExplorerPage() {
     })
   }, [allClients, metric, splitBy, splitByValues])
 
+  // Matrix derived from cross endpoint
+  const matrixRows = useMemo(
+    () => [...new Set((crossData ?? []).map((r: Record<string, unknown>) => String(r.dim1_value)))].sort(),
+    [crossData]
+  )
+  const matrixCols = useMemo(
+    () => [...new Set((crossData ?? []).map((r: Record<string, unknown>) => String(r.dim2_value)))].sort(),
+    [crossData]
+  )
+  const matrixMap = useMemo(() => {
+    const map = new Map<string, Map<string, { total: number; close_rate: number }>>()
+    for (const r of (crossData ?? []) as Record<string, unknown>[]) {
+      const row = String(r.dim1_value)
+      const col = String(r.dim2_value)
+      if (!map.has(row)) map.set(row, new Map())
+      map.get(row)!.set(col, { total: Number(r.total), close_rate: Number(r.close_rate) })
+    }
+    return map
+  }, [crossData])
+  const matrixMaxCount = useMemo(
+    () => Math.max(0, ...(crossData ?? []).map((r: Record<string, unknown>) => Number(r.total))),
+    [crossData]
+  )
+
   type ScatterPoint = { name: string; x: number; y: number; colorGroup?: string }
   type ScatterGroup = { color: string; label: string; data: ScatterPoint[] }
 
-  // Scatter data: when colorBy is set, cross-group by (dimension × colorBy) so each point
-  // represents a real (dim, colorBy) pair — not an arbitrary clients[0] lookup.
   const scatterGroups = useMemo((): ScatterGroup[] => {
     if (!colorBy) {
       const data = groupClients(allClients, dimension).map(({ name, clients }) => ({
@@ -175,7 +234,6 @@ export default function ExplorerPage() {
       return [{ color: COLORS[0], label: "", data }]
     }
 
-    // Cross-group: one point per (dimension × colorBy) pair
     const crossMap = new Map<string, { dimVal: string; colorVal: string; clients: Client[] }>()
     for (const c of allClients) {
       const dimVal = getDimValue(c, dimension)
@@ -185,7 +243,6 @@ export default function ExplorerPage() {
       crossMap.get(key)!.clients.push(c)
     }
 
-    // Group points by colorBy value for separate Scatter components
     const byColor = new Map<string, ScatterPoint[]>()
     for (const { dimVal, colorVal, clients } of crossMap.values()) {
       if (!byColor.has(colorVal)) byColor.set(colorVal, [])
@@ -204,6 +261,19 @@ export default function ExplorerPage() {
     }))
   }, [allClients, dimension, colorBy, scatterX, scatterY])
 
+  const isStacked = (chartType === "bar" || chartType === "hbar") && !!stackBy && stackBy !== dimension
+  const dimLabel = DIMENSIONS.find((d) => d.value === dimension)?.label ?? dimension
+  const stackLabel = DIMENSIONS.find((d) => d.value === stackBy)?.label ?? stackBy
+  const metricLabel = METRICS.find((m) => m.value === metric)?.label ?? metric
+
+  const chartTitle = chartType === "scatter"
+    ? `${METRICS.find(m => m.value === scatterX)?.label} vs ${METRICS.find(m => m.value === scatterY)?.label} por ${dimLabel}`
+    : chartType === "matrix"
+      ? `Tasa de cierre: ${dimLabel} × ${stackLabel}`
+      : isStacked
+        ? `${metricLabel} por ${dimLabel} (apilado por ${stackLabel})`
+        : `${metricLabel} por ${chartType === "line" ? "mes" : dimLabel}`
+
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Explorador Ad-Hoc</h1>
@@ -211,7 +281,6 @@ export default function ExplorerPage() {
       {/* Controls */}
       <Card>
         <CardContent className="pt-4">
-          {/* Mobile: toggle button */}
           <button
             type="button"
             aria-expanded={controlsOpen}
@@ -222,7 +291,6 @@ export default function ExplorerPage() {
             {controlsOpen ? "Ocultar configuración" : "Configurar gráfico"}
           </button>
 
-          {/* Controls: visible on desktop always, toggled on mobile */}
           <div className={`gap-3 ${controlsOpen ? "flex flex-col" : "hidden"} lg:flex lg:flex-row lg:flex-wrap lg:items-center`}>
             {/* Chart type */}
             <select className={inputClass} value={chartType} onChange={(e) => setChartType(e.target.value as ChartType)}>
@@ -230,6 +298,7 @@ export default function ExplorerPage() {
               <option value="hbar">Bar horizontal</option>
               <option value="line">Línea temporal</option>
               <option value="scatter">Scatter</option>
+              <option value="matrix">Matriz</option>
             </select>
 
             {chartType !== "scatter" && (
@@ -240,15 +309,30 @@ export default function ExplorerPage() {
                 <select className={inputClass} value={metric} onChange={(e) => setMetric(e.target.value)}>
                   {METRICS.map((m) => <option key={m.value} value={m.value}>{m.label}</option>)}
                 </select>
-                {chartType === "line" && (
-                  <select className={inputClass} value={splitBy} onChange={(e) => setSplitBy(e.target.value)}>
-                    <option value="">Sin split</option>
-                    {DIMENSIONS.map((d) => <option key={d.value} value={d.value}>{d.label}</option>)}
-                  </select>
-                )}
               </>
             )}
 
+            {/* Line: split by */}
+            {chartType === "line" && (
+              <select className={inputClass} value={splitBy} onChange={(e) => setSplitBy(e.target.value)}>
+                <option value="">Sin split</option>
+                {DIMENSIONS.map((d) => <option key={d.value} value={d.value}>{d.label}</option>)}
+              </select>
+            )}
+
+            {/* Bar / HBar / Matrix: secondary dimension */}
+            {(chartType === "bar" || chartType === "hbar" || chartType === "matrix") && (
+              <select className={inputClass} value={stackBy} onChange={(e) => setStackBy(e.target.value)}>
+                <option value="">
+                  {chartType === "matrix" ? "— Selecciona dimensión secundaria —" : "Sin apilado"}
+                </option>
+                {DIMENSIONS.filter((d) => d.value !== dimension).map((d) => (
+                  <option key={d.value} value={d.value}>{d.label}</option>
+                ))}
+              </select>
+            )}
+
+            {/* Scatter */}
             {chartType === "scatter" && (
               <>
                 <select className={inputClass} value={dimension} onChange={(e) => setDimension(e.target.value)}>
@@ -276,12 +360,7 @@ export default function ExplorerPage() {
       {/* Chart */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm font-medium text-muted-foreground">
-            {chartType === "scatter"
-              ? `${METRICS.find(m => m.value === scatterX)?.label} vs ${METRICS.find(m => m.value === scatterY)?.label} por ${DIMENSIONS.find(d => d.value === dimension)?.label}`
-              : `${METRICS.find(m => m.value === metric)?.label} por ${chartType === "line" ? "mes" : DIMENSIONS.find(d => d.value === dimension)?.label}`
-            }
-          </CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground">{chartTitle}</CardTitle>
         </CardHeader>
         <CardContent>
           {isLoading ? (
@@ -290,7 +369,8 @@ export default function ExplorerPage() {
             </div>
           ) : (
             <>
-              {(chartType === "bar") && (
+              {/* Simple bar */}
+              {chartType === "bar" && !isStacked && (
                 <ResponsiveContainer width="100%" height={320}>
                   <BarChart data={barData} margin={{ top: 4, right: 16, left: -8, bottom: 40 }}>
                     <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
@@ -302,7 +382,24 @@ export default function ExplorerPage() {
                 </ResponsiveContainer>
               )}
 
-              {chartType === "hbar" && (
+              {/* Stacked bar vertical */}
+              {chartType === "bar" && isStacked && (
+                <ResponsiveContainer width="100%" height={320}>
+                  <BarChart data={stackedData} margin={{ top: 4, right: 16, left: -8, bottom: 40 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                    <XAxis dataKey="name" tick={{ fontSize: 11 }} angle={-30} textAnchor="end" interval={0} />
+                    <YAxis tick={{ fontSize: 12 }} unit={metricUnit} />
+                    <Tooltip contentStyle={{ fontSize: 12 }} />
+                    <Legend iconSize={10} formatter={(v) => <span style={{ fontSize: 11 }}>{v}</span>} />
+                    {stackByValues.map((sv, i) => (
+                      <Bar key={sv} dataKey={sv} stackId="a" fill={COLORS[i % COLORS.length]} radius={i === stackByValues.length - 1 ? [4, 4, 0, 0] : undefined} />
+                    ))}
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+
+              {/* Simple hbar */}
+              {chartType === "hbar" && !isStacked && (
                 <ResponsiveContainer width="100%" height={Math.max(280, barData.length * 36)}>
                   <BarChart data={barData} layout="vertical" margin={{ top: 4, right: 24, left: 8, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="3 3" className="stroke-border" horizontal={false} />
@@ -314,6 +411,23 @@ export default function ExplorerPage() {
                 </ResponsiveContainer>
               )}
 
+              {/* Stacked hbar */}
+              {chartType === "hbar" && isStacked && (
+                <ResponsiveContainer width="100%" height={Math.max(280, stackedData.length * 36)}>
+                  <BarChart data={stackedData} layout="vertical" margin={{ top: 4, right: 24, left: 8, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" horizontal={false} />
+                    <XAxis type="number" tick={{ fontSize: 12 }} unit={metricUnit} />
+                    <YAxis type="category" dataKey="name" tick={{ fontSize: 12 }} width={130} />
+                    <Tooltip contentStyle={{ fontSize: 12 }} />
+                    <Legend iconSize={10} formatter={(v) => <span style={{ fontSize: 11 }}>{v}</span>} />
+                    {stackByValues.map((sv, i) => (
+                      <Bar key={sv} dataKey={sv} stackId="a" fill={COLORS[i % COLORS.length]} radius={i === stackByValues.length - 1 ? [0, 4, 4, 0] : undefined} />
+                    ))}
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+
+              {/* Line */}
               {chartType === "line" && (
                 <ResponsiveContainer width="100%" height={320}>
                   <LineChart data={lineData} margin={{ top: 4, right: 16, left: -8, bottom: 0 }}>
@@ -335,6 +449,7 @@ export default function ExplorerPage() {
                 </ResponsiveContainer>
               )}
 
+              {/* Scatter */}
               {chartType === "scatter" && (
                 <ResponsiveContainer width="100%" height={320}>
                   <ScatterChart margin={{ top: 4, right: 16, left: -8, bottom: 0 }}>
@@ -353,7 +468,6 @@ export default function ExplorerPage() {
                             <p className="font-medium">{d.name}</p>
                             <p>{METRICS.find(m => m.value === scatterX)?.label}: {d.x}{scatterXUnit}</p>
                             <p>{METRICS.find(m => m.value === scatterY)?.label}: {d.y}{scatterYUnit}</p>
-                            {d.color && <p>Color: {d.color}</p>}
                           </div>
                         )
                       }}
@@ -370,6 +484,59 @@ export default function ExplorerPage() {
                     )}
                   </ScatterChart>
                 </ResponsiveContainer>
+              )}
+
+              {/* Matrix */}
+              {chartType === "matrix" && (
+                !stackBy || stackBy === dimension ? (
+                  <p className="text-sm text-muted-foreground py-8 text-center">
+                    Selecciona una dimensión secundaria para ver la matriz.
+                  </p>
+                ) : loadingCross ? (
+                  <div className="flex h-48 items-center justify-center">
+                    <Loader2 className="size-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-xs border-collapse">
+                      <thead>
+                        <tr>
+                          <th className="pb-1 pr-3 text-left font-medium text-muted-foreground">{dimLabel}</th>
+                          {matrixCols.map((col) => (
+                            <th key={col} className="pb-1 px-1 text-center font-medium text-muted-foreground whitespace-nowrap">
+                              {col}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {matrixRows.map((row) => (
+                          <tr key={row}>
+                            <td className="py-0.5 pr-3 font-medium whitespace-nowrap">{row}</td>
+                            {matrixCols.map((col) => {
+                              const cell = matrixMap.get(row)?.get(col)
+                              return (
+                                <td key={col} className="py-0.5 px-1 text-center">
+                                  {cell ? (
+                                    <span
+                                      title={`n=${cell.total}`}
+                                      className={`inline-block rounded px-1 py-0.5 ${matrixColor(cell.close_rate, metric, matrixMaxCount)} ${cell.total < 3 ? "opacity-50" : ""}`}
+                                    >
+                                      {cell.close_rate}%
+                                      <span className="block text-[10px] opacity-70">n={cell.total}</span>
+                                    </span>
+                                  ) : (
+                                    <span className="text-muted-foreground/30">—</span>
+                                  )}
+                                </td>
+                              )
+                            })}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )
               )}
             </>
           )}

--- a/frontend/src/pages/ExplorerPage.tsx
+++ b/frontend/src/pages/ExplorerPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
-  LineChart, Line, ScatterChart, Scatter, ZAxis, Legend, Cell,
+  LineChart, Line, ScatterChart, Scatter, ZAxis, Legend,
 } from "recharts"
 import { Loader2, Settings2 } from "lucide-react"
 import { useFilters } from "@/contexts/FiltersContext"
@@ -199,11 +199,11 @@ export default function ExplorerPage() {
 
   // Matrix derived from cross endpoint
   const matrixRows = useMemo(
-    () => [...new Set((crossData ?? []).map((r: Record<string, unknown>) => String(r.dim1_value)))].sort(),
+    () => Array.from(new Set<string>((crossData ?? []).map((r: Record<string, unknown>) => String(r.dim1_value)))).sort(),
     [crossData]
   )
   const matrixCols = useMemo(
-    () => [...new Set((crossData ?? []).map((r: Record<string, unknown>) => String(r.dim2_value)))].sort(),
+    () => Array.from(new Set<string>((crossData ?? []).map((r: Record<string, unknown>) => String(r.dim2_value)))).sort(),
     [crossData]
   )
   const matrixMap = useMemo(() => {

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import {
   BarChart,
@@ -229,6 +230,43 @@ export default function MarketPage() {
     queryFn: () => getCompanySizeByChannel(apiParams),
   })
 
+  // Cross-analysis — sector × channel
+  const sectorChannelRaw: Record<string, unknown>[] = sectorByChannel ?? []
+  const uniqueChannels = useMemo(
+    () => [...new Set(sectorChannelRaw.map((d) => String(d.channel)))].sort(),
+    [sectorByChannel]
+  )
+  const uniqueSectors = useMemo(
+    () => [...new Set(sectorChannelRaw.map((d) => String(d.sector)))].sort(),
+    [sectorByChannel]
+  )
+  const sectorChannelStacked = useMemo(
+    () => buildStackedData(sectorChannelRaw, "sector", "channel", "total", uniqueSectors),
+    [sectorByChannel, uniqueSectors]
+  )
+
+  // Cross-analysis — use case × company size
+  const usecaseSizeRaw: Record<string, unknown>[] = usecaseByCompanySize ?? []
+  const uniqueUseCases = useMemo(
+    () => [...new Set(usecaseSizeRaw.map((d) => String(d.use_case)))].sort(),
+    [usecaseByCompanySize]
+  )
+  const usecaseSizeStacked = useMemo(
+    () => buildStackedData(usecaseSizeRaw, "company_size", "use_case", "total", COMPANY_ORDER),
+    [usecaseByCompanySize]
+  )
+
+  // Cross-analysis — company size × channel
+  const sizeChannelRaw: Record<string, unknown>[] = companySizeByChannel ?? []
+  const uniqueChannelsBySize = useMemo(
+    () => [...new Set(sizeChannelRaw.map((d) => String(d.channel)))].sort(),
+    [companySizeByChannel]
+  )
+  const sizeChannelStacked = useMemo(
+    () => buildStackedData(sizeChannelRaw, "company_size", "channel", "total", COMPANY_ORDER),
+    [companySizeByChannel]
+  )
+
   if (isLoading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -398,25 +436,18 @@ export default function MarketPage() {
             <CardTitle>Canales por sector</CardTitle>
           </CardHeader>
           <CardContent>
-            {(() => {
-              const raw: Record<string, unknown>[] = sectorByChannel ?? []
-              const channels = [...new Set(raw.map((d) => String(d.channel)))]
-              const stacked = buildStackedData(raw, "sector", "channel", "total")
-              return (
-                <ResponsiveContainer width="100%" height={Math.max(200, stacked.length * 36)}>
-                  <BarChart data={stacked} layout="vertical" margin={{ top: 4, right: 16, left: 8, bottom: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" horizontal={false} />
-                    <XAxis type="number" tick={{ fontSize: 11 }} />
-                    <YAxis type="category" dataKey="row" tick={{ fontSize: 11 }} width={90} />
-                    <Tooltip contentStyle={{ fontSize: 12 }} />
-                    <Legend iconSize={8} formatter={(v) => <span style={{ fontSize: 11 }}>{v}</span>} />
-                    {channels.map((ch, i) => (
-                      <Bar key={ch} dataKey={ch} stackId="a" fill={CROSS_COLORS[i % CROSS_COLORS.length]} />
-                    ))}
-                  </BarChart>
-                </ResponsiveContainer>
-              )
-            })()}
+            <ResponsiveContainer width="100%" height={Math.max(200, sectorChannelStacked.length * 36)}>
+              <BarChart data={sectorChannelStacked} layout="vertical" margin={{ top: 4, right: 16, left: 8, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" horizontal={false} />
+                <XAxis type="number" tick={{ fontSize: 11 }} />
+                <YAxis type="category" dataKey="row" tick={{ fontSize: 11 }} width={90} />
+                <Tooltip contentStyle={{ fontSize: 12 }} />
+                <Legend iconSize={8} formatter={(v) => <span style={{ fontSize: 11 }}>{v}</span>} />
+                {uniqueChannels.map((ch, i) => (
+                  <Bar key={ch} dataKey={ch} stackId="a" fill={CROSS_COLORS[i % CROSS_COLORS.length]} />
+                ))}
+              </BarChart>
+            </ResponsiveContainer>
           </CardContent>
         </Card>
 
@@ -430,6 +461,8 @@ export default function MarketPage() {
               rowKey="sector"
               colKey="channel"
               rowLabel="Sector"
+              rowOrder={uniqueSectors}
+              colOrder={uniqueChannels}
             />
           </CardContent>
         </Card>
@@ -442,25 +475,18 @@ export default function MarketPage() {
             <CardTitle>Casos de uso por tamaño de empresa</CardTitle>
           </CardHeader>
           <CardContent>
-            {(() => {
-              const raw: Record<string, unknown>[] = usecaseByCompanySize ?? []
-              const useCases = [...new Set(raw.map((d) => String(d.use_case)))]
-              const stacked = buildStackedData(raw, "company_size", "use_case", "total", COMPANY_ORDER)
-              return (
-                <ResponsiveContainer width="100%" height={240}>
-                  <BarChart data={stacked} margin={{ top: 4, right: 16, left: -8, bottom: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-                    <XAxis dataKey="row" tick={{ fontSize: 11 }} />
-                    <YAxis tick={{ fontSize: 11 }} />
-                    <Tooltip contentStyle={{ fontSize: 12 }} />
-                    <Legend iconSize={8} formatter={(v) => <span style={{ fontSize: 11 }}>{v}</span>} />
-                    {useCases.map((uc, i) => (
-                      <Bar key={uc} dataKey={uc} stackId="a" fill={CROSS_COLORS[i % CROSS_COLORS.length]} />
-                    ))}
-                  </BarChart>
-                </ResponsiveContainer>
-              )
-            })()}
+            <ResponsiveContainer width="100%" height={240}>
+              <BarChart data={usecaseSizeStacked} margin={{ top: 4, right: 16, left: -8, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis dataKey="row" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 11 }} />
+                <Tooltip contentStyle={{ fontSize: 12 }} />
+                <Legend iconSize={8} formatter={(v) => <span style={{ fontSize: 11 }}>{v}</span>} />
+                {uniqueUseCases.map((uc, i) => (
+                  <Bar key={uc} dataKey={uc} stackId="a" fill={CROSS_COLORS[i % CROSS_COLORS.length]} />
+                ))}
+              </BarChart>
+            </ResponsiveContainer>
           </CardContent>
         </Card>
 
@@ -486,25 +512,18 @@ export default function MarketPage() {
           <CardTitle>Canales por tamaño de empresa</CardTitle>
         </CardHeader>
         <CardContent>
-          {(() => {
-            const raw: Record<string, unknown>[] = companySizeByChannel ?? []
-            const channels = [...new Set(raw.map((d) => String(d.channel)))]
-            const stacked = buildStackedData(raw, "company_size", "channel", "total", COMPANY_ORDER)
-            return (
-              <ResponsiveContainer width="100%" height={240}>
-                <BarChart data={stacked} margin={{ top: 4, right: 16, left: -8, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-                  <XAxis dataKey="row" tick={{ fontSize: 11 }} />
-                  <YAxis tick={{ fontSize: 11 }} />
-                  <Tooltip contentStyle={{ fontSize: 12 }} />
-                  <Legend iconSize={8} formatter={(v) => <span style={{ fontSize: 11 }}>{v}</span>} />
-                  {channels.map((ch, i) => (
-                    <Bar key={ch} dataKey={ch} stackId="a" fill={CROSS_COLORS[i % CROSS_COLORS.length]} />
-                  ))}
-                </BarChart>
-              </ResponsiveContainer>
-            )
-          })()}
+          <ResponsiveContainer width="100%" height={240}>
+            <BarChart data={sizeChannelStacked} margin={{ top: 4, right: 16, left: -8, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis dataKey="row" tick={{ fontSize: 11 }} />
+              <YAxis tick={{ fontSize: 11 }} />
+              <Tooltip contentStyle={{ fontSize: 12 }} />
+              <Legend iconSize={8} formatter={(v) => <span style={{ fontSize: 11 }}>{v}</span>} />
+              {uniqueChannelsBySize.map((ch, i) => (
+                <Bar key={ch} dataKey={ch} stackId="a" fill={CROSS_COLORS[i % CROSS_COLORS.length]} />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
Closes #71

## Summary

### Backend
- `GET /api/analytics/cross?dim1=&dim2=` — endpoint genérico de cruce entre dos dimensiones cualesquiera
- Whitelist de 11 dimensiones válidas para prevenir SQL injection vía `getattr`
- Acepta filtros globales (`vendedor`, `date_from`, `date_to`)

### Frontend — `ExplorerPage.tsx`
- Nuevo tipo de chart **Matriz** en el selector
- Selector **Dimensión secundaria** (opcional) para tipos `bar` / `hbar` / `matrix`
- **Stacked bar** vertical y horizontal cuando se selecciona dimensión secundaria
- **Matriz / Heatmap**: filas = dimensión principal, columnas = dimensión secundaria
  - Color por tasa de cierre (verde ≥50%, ámbar ≥30%, rojo <30%)
  - `n=` en cada celda; opacidad reducida para muestras < 3
  - Placeholder si no se seleccionó dimensión secundaria
- Sin dimensión secundaria, el Explorador funciona exactamente igual que antes

### `api.ts`
- `getCross(dim1, dim2, params?)` — llama al nuevo endpoint

## Screenshots
| Stacked bar | Matriz |
|---|---|
| Bar vertical apilado por dimensión secundaria | Heatmap con close_rate por celda |

🤖 Generated with [Claude Code](https://claude.com/claude-code)